### PR TITLE
AdjustProjectSettings can be undone with RestoreProjectSettings

### DIFF
--- a/RestoreProjectSettings.zsh
+++ b/RestoreProjectSettings.zsh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-#  AdjustProjectSettings.zsh
+#  RestoreProjectSettings.zsh
 #  macInstaller
 #
 #  Created by Paulo Raffaelli on 7/14/24.
@@ -15,7 +15,7 @@ echo "Background service bundle identifier is $HELPERNAME"
 echo "Signing cert for both app and service is $SIGNINGCERT"
 
 # sample invocation
-# SIGNINGCERT="Developer ID Application: Paulo Raffaelli (2XEVFK8ZST)" CLIENTNAME="com.greenkitty.macinstaller" HELPERNAME="com.greenkitty.macinstallerhelper" ./AdjustProjectSettings.zsh
+# SIGNINGCERT="Developer ID Application: Paulo Raffaelli (2XEVFK8ZST)" CLIENTNAME="com.greenkitty.macinstaller" HELPERNAME="com.greenkitty.macinstallerhelper" ./RestoreProjectSettings.zsh
 # Note that if CLIENTNAME is a prefix of HELPERNAME, this script works.
 # If HELPERNAME is a prefix of CLIENTNAME, then this script will fail.
 
@@ -36,22 +36,22 @@ echo "Client app UI test target name is $CLIENTNAMEUITESTS"
 # target name is 'HELPERNAME'
 # HELPERNAME target Bundle identifier 'HELPERNAME'
 # HELPERNAME target Build setting Objective-C Bridging Header = 'HELPERNAME/HELPERNAME-Bridging-Header.h'
-sed "s/HELPERNAME/$HELPERNAME/g" macInstaller/macInstaller.xcodeproj/project.pbxproj > temp.out
+sed "s/$HELPERNAME/HELPERNAME/g" macInstaller/macInstaller.xcodeproj/project.pbxproj > temp.out
 
 # macInstaller target Bundle identifier 'CLIENTNAME'
-sed "s/CLIENTNAMETESTS/$CLIENTNAMETESTS/g" temp.out > temp2.out
+sed "s/$CLIENTNAMETESTS/CLIENTNAMETESTS/g" temp.out > temp2.out
 rm temp.out
-sed "s/CLIENTNAMEUITESTS/$CLIENTNAMEUITESTS/g" temp2.out > temp3.out
+sed "s/$CLIENTNAMEUITESTS/CLIENTNAMEUITESTS/g" temp2.out > temp3.out
 rm temp2.out
-sed "s/CLIENTNAME/$CLIENTNAME/g" temp3.out > temp4.out
+sed "s/$CLIENTNAME/CLIENTNAME/g" temp3.out > temp4.out
 rm temp3.out
 
 # cert used to sign executables
-sed "s/SIGNINGCERT/$SIGNINGCERT/g" temp4.out > temp5.out
+sed "s/$SIGNINGCERT/SIGNINGCERT/g" temp4.out > temp5.out
 rm temp4.out
 
 # dev team
-sed "s/SIGNINGTEAM/$SIGNINGTEAM/g" temp5.out > temp6.out
+sed "s/$SIGNINGTEAM/SIGNINGTEAM/g" temp5.out > temp6.out
 rm temp5.out
 
 # copy modified .pbxproj file over
@@ -65,57 +65,57 @@ mv temp6.out macInstaller/macInstaller.xcodeproj/project.pbxproj
 echo "SMPrivilegedExecutables in macInstaller/macInstaller/Info.plist"
 plutil -remove "SMPrivilegedExecutables" macInstaller/macInstaller/Info.plist
 plutil -insert "SMPrivilegedExecutables" -dictionary macInstaller/macInstaller/Info.plist
-plutil -insert "SMPrivilegedExecutables.$ESCAPEDHELPER" -string "identifier \"$HELPERNAME\" and anchor apple generic and certificate leaf[subject.CN] = \"$SIGNINGCERT\"" macInstaller/macInstaller/Info.plist
+plutil -insert "SMPrivilegedExecutables.HELPERNAME" -string 'identifier "CLIENTNAME" and anchor apple generic and certificate leaf[subject.CN] = "SIGNINGIDENT"' macInstaller/macInstaller/Info.plist
 
 # macInstaller/HELPERNAME/Info.plist
-# CFBundleIdentifier: HELPERNAME
+# CFBundleIdentifier: $HELPERNAME
 # CFBundleInfoDictionaryVersion: 6.0
 # SMAuthorizedClients: array
 # - identifier "CLIENTNAME" and anchor apple generic and certificate leaf[subject.CN] = "SIGNINGIDENT"
 echo "CFBundleIdentifier in macInstaller/$HELPERNAME/Info.plist"
-plutil -remove "CFBundleIdentifier" macInstaller/HELPERNAME/Info.plist
-plutil -insert "CFBundleIdentifier" -string "$HELPERNAME" macInstaller/HELPERNAME/Info.plist
+plutil -remove "CFBundleIdentifier" macInstaller/$HELPERNAME/Info.plist
+plutil -insert "CFBundleIdentifier" -string "HELPERNAME" "macInstaller/$HELPERNAME/Info.plist"
 
 # key Clients allowed to add and remove tool
 # item 0: ''
 #    identifier "HELPERNAME" and anchor apple generic and certificate leaf[subject.CN] = "SIGNINGCERT"
 echo "SMAuthorizedClients in macInstaller/$HELPERNAME/Info.plist"
-plutil -remove "SMAuthorizedClients" macInstaller/HELPERNAME/Info.plist
-plutil -insert "SMAuthorizedClients" -array macInstaller/HELPERNAME/Info.plist
-plutil -insert "SMAuthorizedClients.0" -string "identifier \"$CLIENTNAME\" and anchor apple generic and certificate leaf[subject.CN] = \"$SIGNINGCERT\"" macInstaller/HELPERNAME/Info.plist
+plutil -remove "SMAuthorizedClients" "macInstaller/$HELPERNAME/Info.plist"
+plutil -insert "SMAuthorizedClients" -array "macInstaller/$HELPERNAME/Info.plist"
+plutil -insert "SMAuthorizedClients.0" -string 'identifier "CLIENTNAME" and anchor apple generic and certificate leaf[subject.CN] = "SIGNINGIDENT"' "macInstaller/$HELPERNAME/Info.plist"
 
-# macInstaller/HELPERNAME/launchd.plist
+# macInstaller/$HELPERNAME/launchd.plist
 # key Label
 # value 'HELPERNAME'
 echo "Label in macInstaller/$HELPERNAME/launchd.plist"
-plutil -remove "Label" macInstaller/HELPERNAME/launchd.plist
-plutil -insert "Label" -string "$HELPERNAME" macInstaller/HELPERNAME/launchd.plist
+plutil -remove "Label" "macInstaller/$HELPERNAME/launchd.plist"
+plutil -insert "Label" -string "HELPERNAME" "macInstaller/$HELPERNAME/launchd.plist"
 
 # key MachServices (array)
 # - key 'HELPERNAME' value YES
 echo "MachServices in macInstaller/$HELPERNAME/launchd.plist"
-plutil -remove "MachServices" macInstaller/HELPERNAME/launchd.plist
-plutil -insert "MachServices" -dictionary macInstaller/HELPERNAME/launchd.plist
-plutil -insert "MachServices.$ESCAPEDHELPER" -bool true macInstaller/HELPERNAME/launchd.plist
+plutil -remove "MachServices" "macInstaller/$HELPERNAME/launchd.plist"
+plutil -insert "MachServices" -dictionary "macInstaller/$HELPERNAME/launchd.plist"
+plutil -insert "MachServices.HELPERNAME" -bool true "macInstaller/$HELPERNAME/launchd.plist"
 
-# macInstaller/HELPERNAME/XPCServer.swift
+# macInstaller/$HELPERNAME/XPCServer.swift
 #         let entitlements = "identifier \"CLIENTNAME\" and anchor apple generic and certificate leaf[subject.CN] = \"SIGNINGCERT\""
 echo "Updating XPCServer.swift with $CLIENTNAME and $SIGNINGCERT"
-sed "s/CLIENTNAME/$CLIENTNAME/g" macInstaller/HELPERNAME/XPCServer.swift > temp.out
-sed "s/SIGNINGCERT/$SIGNINGCERT/g" temp.out > temp2.out
+sed "s/$CLIENTNAME/CLIENTNAME/g" "macInstaller/$HELPERNAME/XPCServer.swift" > temp.out
+sed "s/$SIGNINGCERT/SIGNINGCERT/g" temp.out > temp2.out
 rm temp.out
-rm macInstaller/HELPERNAME/XPCServer.swift
-mv temp2.out macInstaller/HELPERNAME/XPCServer.swift
+rm "macInstaller/$HELPERNAME/XPCServer.swift"
+mv temp2.out "macInstaller/$HELPERNAME/XPCServer.swift"
 
 # macInstaller/Shared/Constants.swift
 echo "Updating Constants.swift with $HELPERNAME"
-sed "s/HELPERNAME/$HELPERNAME/g" macInstaller/Shared/Constants.swift > temp.out
+sed "s/$HELPERNAME/HELPERNAME/g" macInstaller/Shared/Constants.swift > temp.out
 rm macInstaller/Shared/Constants.swift
 mv temp.out macInstaller/Shared/Constants.swift
 
-mv "macInstaller/HELPERNAME/HELPERNAME-Bridging-Header.h" "macInstaller/HELPERNAME/$HELPERNAME-Bridging-Header.h" 
+mv "macInstaller/$HELPERNAME/$HELPERNAME-Bridging-Header.h" "macInstaller/$HELPERNAME/HELPERNAME-Bridging-Header.h" 
 
 # subfolder named HELPERNAME/
-echo "Copying macInstaller/HELPERNAME directory to macInstaller/$HELPERNAME"
-mv "macInstaller/HELPERNAME/" "macInstaller/$HELPERNAME/" 
+echo "Copying macInstaller/$HELPERNAME directory to macInstaller/HELPERNAME"
+mv "macInstaller/$HELPERNAME/" "macInstaller/HELPERNAME/" 
 

--- a/ThereAndBack.zsh
+++ b/ThereAndBack.zsh
@@ -1,0 +1,8 @@
+#!/bin/zsh
+
+# there...
+SIGNINGCERT="Developer ID Application: Paulo Raffaelli (2XEVFK8ZST)" CLIENTNAME="com.greenkitty.macinstaller" HELPERNAME="com.greenkitty.macinstallerhelper" ./AdjustProjectSettings.zsh
+
+# ..and back
+SIGNINGCERT="Developer ID Application: Paulo Raffaelli (2XEVFK8ZST)" CLIENTNAME="com.greenkitty.macinstaller" HELPERNAME="com.greenkitty.macinstallerhelper" ./RestoreProjectSettings.zsh
+

--- a/macInstaller/HELPERNAME/Info.plist
+++ b/macInstaller/HELPERNAME/Info.plist
@@ -8,7 +8,7 @@
 	<string>6.0</string>
 	<key>SMAuthorizedClients</key>
 	<array>
-		<string>identifier &quot;CLIENTNAME&quot; and anchor apple generic and certificate leaf[subject.CN] = &quot;SIGNINGIDENT&quot;</string>
+		<string>identifier "CLIENTNAME" and anchor apple generic and certificate leaf[subject.CN] = "SIGNINGIDENT"</string>
 	</array>
 </dict>
 </plist>

--- a/macInstaller/macInstaller/Info.plist
+++ b/macInstaller/macInstaller/Info.plist
@@ -5,7 +5,7 @@
 	<key>SMPrivilegedExecutables</key>
 	<dict>
 		<key>HELPERNAME</key>
-		<string>identifier &quot;CLIENTNAME&quot; and anchor apple generic and certificate leaf[subject.CN] = &quot;SIGNINGIDENT&quot;</string>
+		<string>identifier "CLIENTNAME" and anchor apple generic and certificate leaf[subject.CN] = "SIGNINGIDENT"</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
The script ThereAndBack is meant to take a clean checkout of the repository and customize the bundle identifiers for the installer application and the helper application and set the development team used to codesign both using AdjustprojectSettings, then undo the customization using RestoreProjectSettings.

macInstaller/HELPERNAME/Info.plist and macInstaller/macInstaller/Info.plist needed to have the embedded strings changed to use " instead of &quot; as delimiters, because plutil can write strings with " in them, but trying to write '&quot;' caused various XML escapes to be applied to the string before it was written, making the final result not match what the script source suggested it would be. This looked like a rich source of silent bugs.