### PR TITLE
Added styling to sample license HTML and turned Javascript off in loa…

### DIFF
--- a/macInstaller/License.html
+++ b/macInstaller/License.html
@@ -2,6 +2,10 @@
 <html>
 <head>
 <style>
+:root {
+    color-scheme: light dark;
+}
+    
 h1 {text-align: center;}
 p {text-align: left; text-indent: 4em;}
 div {text-align: center;}

--- a/macInstaller/macInstaller/Licence Helpers/HTMLView.swift
+++ b/macInstaller/macInstaller/Licence Helpers/HTMLView.swift
@@ -20,6 +20,8 @@ struct LicenseHTMLView: NSViewRepresentable {
  
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = false
+        
         let webView = WKWebView(frame: .zero, configuration: config)
 
         webView.allowsBackForwardNavigationGestures = false


### PR DESCRIPTION
…ded HTML

There's no reason for Javascript to be enabled, and the added styles make the license update its appearance as we switch from dark to light mode.